### PR TITLE
fix: remove unnecessary -- from pnpm run build in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       uses: DevExpress/github-actions/install-internal-package@main
 
     - name: Build
-      run: pnpm run build -- --configuration=production --base-href https://devexpress.github.io/devextreme-angular-template/ --extract-licenses=false
+      run: pnpm run build --configuration=production --base-href https://devexpress.github.io/devextreme-angular-template/ --extract-licenses=false
 
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6


### PR DESCRIPTION
In pnpm, `--` is not needed to pass arguments to scripts (unlike npm). The `--` was causing pnpm to inject a literal `"--"` into the argument list passed to `ng build`.